### PR TITLE
Adding a role for creating a tang key

### DIFF
--- a/inventory/tang-server
+++ b/inventory/tang-server
@@ -1,0 +1,2 @@
+[tang-server]
+mgmt ansible_host=10.70.56.203 ansible_user=root

--- a/roles/create-tang-key/defaults/main.yml
+++ b/roles/create-tang-key/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+tang_url: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:7500"

--- a/roles/create-tang-key/tasks/main.yml
+++ b/roles/create-tang-key/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Install expect package
+  package:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - python3-pexpect
+    - tang
+    - clevis
+
+- name: Create clevis script
+  copy:
+    dest: /tmp/clevis.sh
+    content: |
+      echo $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1) | clevis-encrypt-tang '{"url":"{{ tang_url }}"}'
+
+- name: Run clevis-script
+  expect:
+    timeout: 5
+    command: bash /tmp/clevis.sh
+    responses:
+      (.*)ynYN(.*): y
+  register: clevis_output
+  failed_when: "clevis_output.rc == 1"
+
+- name: Store the output in a key
+  set_fact:
+    secret_key: "{{ clevis_output.stdout.split() | last }}"


### PR DESCRIPTION
Essentially. Prereqs are:
- Setup a tang-server (will add a role for that next)
- Add ssh key to tang-server so you can login
- Execute role
- Use the fact secret_key wherever required in the subsequent steps.